### PR TITLE
Fails when `allow_url_fopen` is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ For these steps, you must have an Azure subscription with access to the Azure Ac
 
 ### 3. Configure the plugin
 
-Configuration of the AADSSO plugin is currently done in a `Settings.json` file. This repo contains a `Settings.template.json` file that can be used as an example. Make a copy and rename it as `Settings.json`.
+Configuration of the AADSSO plugin is currently done in a `Settings.json` file. This repo contains a `Settings.template.json` file that can be used as an example. Make a copy and rename it as `Settings.json`.  Move the `Settings.json` file out of your publicly accessible files, and define its path in `wp-config.php`
 
-The minimal fields required are:
+```php
+define( 'AADSSO_SETTINGS_PATH', '/path/to/Settings.json' );
+```
+
+Edit this file to match your configuration.  The minimal fields required are:
 
 - `org_display_name` The display name of the organization, used only in the link in the login page. 
 - `client_id` The application's client ID (from the application configuration page)

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -44,6 +44,12 @@ class AADSSO {
 		// Set the redirect urls
 		$this->settings->redirect_uri = wp_login_url();
 		$this->settings->logout_redirect_uri = wp_login_url();
+		
+		// if we don't have the facilities to use fopen, stop plugin initiation.
+		if( ! ini_get('allow_url_fopen') ) {
+			// consider throwing user-friendly error
+			return;
+		} 
 
 		// If plugin is not configured, we shouldn't proceed.
 		if ( ! $this->plugin_is_configured() ) {

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -14,7 +14,7 @@ defined('ABSPATH') or die("No script kiddies please!");
 define( 'AADSSO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'AADSSO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
-define( 'AADSSO_SETTINGS_PATH', AADSSO_PLUGIN_DIR . '/Settings.json' );
+define( 'AADSSO_SETTINGS_PATH', '/home/bradkovach/.ad_settings' );
 
 // Proxy to be used for calls, should be useful for tracing with Fiddler
 // BUGBUG: Doesn't actually work, at least not with WP running on WAMP stack
@@ -415,7 +415,7 @@ if ( ! file_exists( AADSSO_SETTINGS_PATH ) ) {
 }
 
 // show a warning if Settings.json is in a publicly accessible location.
-if( strpos(AADSSO_SETTINGS_PATH, get_home_path() ) == 0 ) {
+if( strpos( AADSSO_SETTINGS_PATH, AADSSO_PLUGIN_DIR ) === 0 ) {
 	function addsso_dangerous_settings_json_location () {
 		echo '<div id="settings_json_location" class="error"><p>'
 			. __(

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -44,12 +44,6 @@ class AADSSO {
 		// Set the redirect urls
 		$this->settings->redirect_uri = wp_login_url();
 		$this->settings->logout_redirect_uri = wp_login_url();
-		
-		// if we don't have the facilities to use fopen, stop plugin initiation.
-		if( ! ini_get('allow_url_fopen') ) {
-			// consider throwing user-friendly error
-			return;
-		} 
 
 		// If plugin is not configured, we shouldn't proceed.
 		if ( ! $this->plugin_is_configured() ) {
@@ -395,23 +389,39 @@ EOF;
 	}
 }
 
-$settings = AADSSO_Settings::loadSettingsFromJSON(AADSSO_SETTINGS_PATH);
-$aadsso = AADSSO::getInstance($settings);
+// $settings = AADSSO_Settings::loadSettingsFromJSON(AADSSO_SETTINGS_PATH);
+// $aadsso = AADSSO::getInstance($settings);
 
-if ( ! file_exists( AADSSO_SETTINGS_PATH ) ) {
-	function addsso_settings_missing_notice () {
+// if we don't have the facilities to use fopen, stop plugin initiation.
+if( ! ini_get('allow_url_fopen') ) {
+	function aadsso_allow_url_fopen () {
 		echo '<div id="message" class="error"><p>'
 			. __(
-				'Azure Active Directory Single Sign-on for WordPress requires a Settings.json file '
-					. ' to be added to the plugin.',
+				'Azure Active Directory Single Sign-on for WordPress requires support for <code>allow_url_fopen</code>. '
+					. ' Check with your host or server administrator for assistance enabling <code>allow_url_fopen</code>',
 				'aad-sso-wordpress'
 			)
 			.'</p></div>';
 	}
-	add_action( 'all_admin_notices', 'addsso_settings_missing_notice' );
-} else {
-	$settings = AADSSO_Settings::loadSettingsFromJSON(AADSSO_SETTINGS_PATH);
-	$aadsso = AADSSO::getInstance($settings);
+	add_action( 'all_admin_notices', 'aadsso_allow_url_fopen');
+}
+else
+{
+	if ( ! file_exists( AADSSO_SETTINGS_PATH ) ) {
+		function addsso_settings_missing_notice () {
+			echo '<div id="message" class="error"><p>'
+				. __(
+					'Azure Active Directory Single Sign-on for WordPress requires a Settings.json file '
+						. ' to be added to the plugin.',
+					'aad-sso-wordpress'
+				)
+				.'</p></div>';
+		}
+		add_action( 'all_admin_notices', 'addsso_settings_missing_notice' );
+	} else {
+		$settings = AADSSO_Settings::loadSettingsFromJSON(AADSSO_SETTINGS_PATH);
+		$aadsso = AADSSO::getInstance($settings);
+	}
 }
 
 // show a warning if Settings.json is in a publicly accessible location.

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -399,7 +399,7 @@ $settings = AADSSO_Settings::loadSettingsFromJSON(AADSSO_SETTINGS_PATH);
 $aadsso = AADSSO::getInstance($settings);
 
 if ( ! file_exists( AADSSO_SETTINGS_PATH ) ) {
-	function addsso_settings_missing_noticein () {
+	function addsso_settings_missing_notice () {
 		echo '<div id="message" class="error"><p>'
 			. __(
 				'Azure Active Directory Single Sign-on for WordPress requires a Settings.json file '
@@ -412,6 +412,20 @@ if ( ! file_exists( AADSSO_SETTINGS_PATH ) ) {
 } else {
 	$settings = AADSSO_Settings::loadSettingsFromJSON(AADSSO_SETTINGS_PATH);
 	$aadsso = AADSSO::getInstance($settings);
+}
+
+// show a warning if Settings.json is in a publicly accessible location.
+if( strpos(AADSSO_SETTINGS_PATH, get_home_path() ) == 0 ) {
+	function addsso_dangerous_settings_json_location () {
+		echo '<div id="settings_json_location" class="error"><p>'
+			. __(
+				'The Settings.json file is in a publicly accessible location. '
+					.'Consider moving the file and adjusting AADSSO_SETTINGS_PATH.',
+				'aad-sso-wordpress'
+			)
+			.'</p></div>';
+	}
+	add_action( 'all_admin_notices', 'addsso_dangerous_settings_json_location' );
 }
 
 if ( ! function_exists( 'com_create_guid' ) ) {


### PR DESCRIPTION
If the user's web server does not support allow_url_fopen, the plugin will be unable to function.  This is a quick fix to prevent the plugin from causing fatal PHP errors during init/construction.