### PR TITLE
add ability to assign multiple user roles based on AAD response

### DIFF
--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -387,20 +387,26 @@ class AADSSO {
 
 		// Determine which WordPress role the AAD group corresponds to.
 		// TODO: Check for error in the group membership response
-		$role_to_set = $this->settings->default_wp_role;
+		$role_to_set = array();
+
 		if ( ! empty( $group_memberships->value ) ) {
 			foreach ( $this->settings->aad_group_to_wp_role_map as $aad_group => $wp_role ) {
 				if ( in_array( $aad_group, $group_memberships->value ) ) {
-					$role_to_set = $wp_role;
-					break;
+					array_push( $role_to_set, $wp_role );
 				}
 			}
 		}
 
-		if ( null != $role_to_set || "" != $role_to_set ) {
-			// Set the role on the WordPress user
-			$user->set_role( $role_to_set );
-		} else {
+		if ( ! empty( $role_to_set ) ) {
+			$user->set_role("");
+			foreach ( $role_to_set as $role ){
+				$user->add_role( $role );
+			}
+		}
+		else if ( null != $this->settings->default_wp_role || "" != $this->settings->default_wp_role ){
+			$user->set_role( $this->settings->default_wp_role );
+		}
+		else{
 			return new WP_Error(
 				'user_not_member_of_required_group',
 				sprintf(


### PR DESCRIPTION
Pull request to add the ability to assignee multiple roles to a user. 

Should close #89 and #73 and also replace #74 

Tested against:

- User with no role assigned with default role disabled
- User with no role assigned with default role enabled
- User with a single role assigned through AAD
- User with multiple roles assigned through AAD
- User changing roles through AAD disables previous roles

All conditions appear to be working as expected