### PR TITLE
Docs and rename for 'match on alias' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ Users are matched by their email address in WordPress, and whichever role they h
 | Reply URL | https://www.example.com/blog/wp-login.php
 | Field to match to UPN | Email Address
 
+### Match on username alias
+
+Users are matched by their login names in WordPress and the alias portion of their Azure AD UserPrincipalName. Whichever role they have in WordPress is maintained.
+
+| Setting | Example value
+| --- | ---
+| Display name | Contoso
+| Client ID | 9054eff5-bfef-4cc5-82fd-8c35534e48f9
+| Client Secret | NTY5MmE5YjMwMGY2MWQ0NjU5MzYxNjdjNzE1OGNiZmY=
+| Reply URL | https://www.example.com/blog/wp-login.php
+| Field to match to UPN | Login Name
+| Match on alias of the UPN | Yes
+
 ### Group membership-based roles, no default role
 
 Users are matched by their login names in WordPress, and WordPress roles are dictated by membership to a given Azure AD group. Access is denied if they are not members of any of these groups.

--- a/Settings.php
+++ b/Settings.php
@@ -55,12 +55,12 @@ class AADSSO_Settings {
 	public $field_to_match_to_upn = '';
 
 	/**
-	 * Indicates whether or not a WordPress user should be matched against the authenticated user's logon name
-	* which is extracted from the UPN
+	 * Indicates whether or not a WordPress user should be matched against the authenticated user's
+	 * alias portion of their UserPrincipalName ('bob'' in 'bob@example.com').
 	 *
-	 * @var boolean Whether or not to match based on logon name
+	 * @var boolean Whether or not to match based UPN alias
 	 */
-	public $match_on_username = false;
+	public $match_on_upn_alias = false;
 
 	/**
 	* Indicates whether or not a WordPress user should be auto-provisioned if a user is able to
@@ -155,7 +155,7 @@ class AADSSO_Settings {
 			'field_to_match_to_upn' => 'email',
 			'default_wp_role' => null,
 			'enable_auto_provisioning' => false,
-			'match_on_username' => false,
+			'match_on_upn_alias' => false,
 			'enable_auto_forward_to_aad' => false,
 			'enable_aad_group_to_wp_role' => false,
 			'redirect_uri' => wp_login_url(),

--- a/SettingsPage.php
+++ b/SettingsPage.php
@@ -258,9 +258,9 @@ class AADSSO_Settings_Page {
 		);
 
 		add_settings_field(
-			'match_on_username', // id
-			__( 'Match on logon name', 'aad-sso-wordpress' ), // title
-			array( $this, 'match_on_username_callback' ), // callback
+			'match_on_upn_alias', // id
+			__( 'Match on alias of the UPN', 'aad-sso-wordpress' ), // title
+			array( $this, 'match_on_upn_alias_callback' ), // callback
 			'aadsso_settings_page', // page
 			'aadsso_settings_general' // section
 		);
@@ -373,7 +373,7 @@ class AADSSO_Settings_Page {
 			'enable_auto_provisioning',
 			'enable_auto_forward_to_aad',
 			'enable_aad_group_to_wp_role',
-			'match_on_username',
+			'match_on_upn_alias',
 		);
 		foreach ( $boolean_settings as $boolean_setting )
 		{
@@ -550,19 +550,20 @@ class AADSSO_Settings_Page {
 		<?php
 		printf(
 			'<p class="description">%s</p>',
-			__('This specifies the WordPress user field which will be used to match to the Azure AD user\'s '
-			 . 'UserPrincipalName. Email Address is fine for most instances.', 'aad-sso-wordpress')
+			__( 'This specifies the WordPress user field which will be used to match to the Azure AD user\'s '
+			  . 'UserPrincipalName.', 'aad-sso-wordpress' )
 		);
 	}
 
 	/**
-	 * Renders the `match_on_username` checkbox control.
+	 * Renders the `match_on_upn_alias` checkbox control.
 	 */
-	public function match_on_username_callback() {
+	public function match_on_upn_alias_callback() {
 		$this->render_checkbox_field(
-			'match_on_username',
-			__( 'Match WordPress users based on their Azure AD username',
-				'aad-sso-wordpress' )
+			'match_on_upn_alias',
+			__( 'Match WordPress users based on the alias of their Azure AD UserPrincipalName. For example, '
+			  . 'Azure AD username <code>bob@example.com</code> will match WordPress user <code>bob</code>.',
+			    'aad-sso-wordpress' )
 		);
 	}
 

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -328,7 +328,7 @@ class AADSSO {
 
 		$user = get_user_by( $this->settings->field_to_match_to_upn, $unique_name );
 
-		if( true === $this->settings->match_on_username ) {
+		if( true === $this->settings->match_on_upn_alias ) {
 			if ( ! is_a( $user, 'WP_User' ) ) {
 				$username = explode( sprintf( '@%s', $this->settings->org_domain_hint ), $unique_name );
 				$user = get_user_by( $this->settings->field_to_match_to_upn, $username[0] );


### PR DESCRIPTION
 * Rename `match_on_username` setting to `match_on_upn_alias`, to avoid confusion with usename term.
 * Adds documentation for this new settings (both in UI and README).