### PR TITLE
The UPN property doesn't exist, but OID does

### DIFF
--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -296,7 +296,7 @@ class AADSSO {
 					// exists in WordPress (either because it already existed, or we created it
 					// on-the-fly). All that's left is to set the roles based on group membership.
 					if ( true === $this->settings->enable_aad_group_to_wp_role ) {
-						$user = $this->update_wp_user_roles( $user, $jwt->upn, $jwt->tid );
+						$user = $this->update_wp_user_roles( $user, $jwt->oid, $jwt->tid );
 					}
 				}
 


### PR DESCRIPTION
Despite using all of the settings in recommended in the README I'm unable to access a site configured to assign the Wordpress role based on AAD group membership. What I found was that the code wants to look at the $jwt->upn property but it doesn't exist. OID is the proper property.