### PR TITLE
Feature/filter debug constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ With these steps, you will register an application with Azure AD. This applicati
 
     ![Adding a reply URL](https://user-images.githubusercontent.com/231140/29496951-54b63d74-85de-11e7-848d-d1ed0b7ce105.png)
 
-5. Under **Required permissions**, choose the "Windows Azure Active Directory" API. You will need at minimum delegated permissions to "Sign in and read user profile". If you wish to map Azure AD groups to WordPress roles, you will also need delegated permission to "Read all groups". Once you've selected the permissions, click **Save**.
+5. Under **Required permissions**, choose the "Windows Azure Active Directory" API. You will need at minimum delegated permissions to "Sign in and read user profile". If you wish to map Azure AD groups to WordPress roles, you will also need delegated permission to "Read directory data". Once you've selected the permissions, click **Save**.
     
-    **Important**: The "Read all groups" delegated permissions requires a tenant administrator to consent to the application. The tenant administrator can use the **Grant Permissions** option to grant permissions (i.e. consent) on behalf of all users.
+    **Important**: The "Read directory data" delegated permissions requires a tenant administrator to consent to the application. The tenant administrator can use the **Grant Permissions** option to grant permissions (i.e. consent) on behalf of all users.
 
-    ![Delegated permissions to sign in and read all groups](https://user-images.githubusercontent.com/231140/29496967-cc635a78-85de-11e7-8e3c-34cc3ca39ac8.png)
+    ![Delegated permissions to sign in and read directory data](https://user-images.githubusercontent.com/231140/30487748-a6fe8e5a-9a34-11e7-8730-ce44472817cf.png)
 
 7. Under **Keys**, provide a new secret key description and duration, and click **Save**. After saving, the secret key value will appear. Copy it, as this is the only time it will be available.
 

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -17,7 +17,7 @@ define( 'AADSSO', 'aad-sso-wordpress' );
 define( 'AADSSO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'AADSSO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
-defined( 'AADSSO_DEBUG' ) or define( 'AADSSO_DEBUG', FALSE );
+
 defined( 'AADSSO_DEBUG_LEVEL' ) or define( 'AADSSO_DEBUG_LEVEL', 0 );
 
 // Proxy to be used for calls, should be useful for tracing with Fiddler
@@ -638,8 +638,24 @@ class AADSSO {
 		 */
 		do_action( 'aadsso_debug_log', $message );
 
-		// AADSSO_DEBUG and AADSSO_DEBUG_LEVEL are already defined.
-		if ( AADSSO_DEBUG && AADSSO_DEBUG_LEVEL >= $level ) {
+		/**
+		 * Allow other plugins or themes to set the debug status of this plugin.
+		 *
+		 * @since 0.6.2
+		 * @param bool The current debug status.
+		 */
+		$aad_sso_debug = apply_filters( 'aadsso_debug', false );
+
+
+		/**
+		 * Allow other plugins or themes to set the debug level
+		 * @since 0.6.2
+		 * @param int
+		 */
+		$aad_sso_debug_level = apply_filters( 'aadsso_debug_level', 0 );
+
+
+		if ( true === $aad_sso_debug && $aad_sso_debug_level >= $level ) {
 			if ( false === strpos( $message, "\n" ) ) {
 				error_log( 'AADSSO: ' . $message );
 			} else {

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -5,7 +5,7 @@ Plugin Name: Single Sign-on with Azure Active Directory
 Plugin URI: http://github.com/psignoret/aad-sso-wordpress
 Description: Allows you to use your organization's Azure Active Directory user accounts to log in to WordPress. If your organization is using Office 365, your user accounts are already in Azure Active Directory. This plugin uses OAuth 2.0 to authenticate users, and the Azure Active Directory Graph to get group membership and other details.
 Author: Philippe Signoret
-Version: 0.6.2
+Version: 0.6.3
 Author URI: https://www.psignoret.com/
 Text Domain: aad-sso-wordpress
 Domain Path: /languages/
@@ -17,7 +17,7 @@ define( 'AADSSO', 'aad-sso-wordpress' );
 define( 'AADSSO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'AADSSO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
-
+defined( 'AADSSO_DEBUG' ) or define( 'AADSSP_DEBUG', FALSE );
 defined( 'AADSSO_DEBUG_LEVEL' ) or define( 'AADSSO_DEBUG_LEVEL', 0 );
 
 // Proxy to be used for calls, should be useful for tracing with Fiddler
@@ -641,21 +641,21 @@ class AADSSO {
 		/**
 		 * Allow other plugins or themes to set the debug status of this plugin.
 		 *
-		 * @since 0.6.2
+		 * @since 0.6.3
 		 * @param bool The current debug status.
 		 */
-		$aad_sso_debug = apply_filters( 'aadsso_debug', false );
+		$debug_enabled = apply_filters( 'aadsso_debug', AADSSO_DEBUG );
 
 
 		/**
 		 * Allow other plugins or themes to set the debug level
-		 * @since 0.6.2
+		 * @since 0.6.3
 		 * @param int
 		 */
-		$aad_sso_debug_level = apply_filters( 'aadsso_debug_level', 0 );
+		$debug_level = apply_filters( 'aadsso_debug_level', AADSSO_DEBUG_LEVEL );
 
 
-		if ( true === $aad_sso_debug && $aad_sso_debug_level >= $level ) {
+		if ( true === $debug_enabled && $debug_level >= $level ) {
 			if ( false === strpos( $message, "\n" ) ) {
 				error_log( 'AADSSO: ' . $message );
 			} else {


### PR DESCRIPTION
With the current set up, the constants `AADSSO_DEBUG` and `AADSSO_DEBUG_LEVEL` will always be set to their default values. Theme code is loaded after any plugins and there is no guarantee that other plugins will be able to set this value first.

This PR introduces two new filters to allow consistent access to manage these constants and will allow this plugin to reflect if WordPress setup to be in debug mode by using something like the following:

```
add_filter( 'aadsso_debug', function(){
    return ( defined('WP_DEBUG') && true === WP_DEBUG );
});

```
