### PR TITLE
Allow for use of env variables to set redirect URIs

### DIFF
--- a/AuthorizationHelper.php
+++ b/AuthorizationHelper.php
@@ -26,7 +26,7 @@ class AADSSO_AuthorizationHelper
 					'domain_hint'   => $settings->org_domain_hint,
 					'client_id'     => $settings->client_id,
 					'resource'      => $settings->graph_endpoint,
-					'redirect_uri'  => $settings->redirect_uri,
+					'redirect_uri'  => $_SERVER['ADD_REDIRECT_URI'] ?: $settings->redirect_uri,
 					'state'         => $antiforgery_id,
 					'nonce'         => $antiforgery_id,
 				) );
@@ -49,7 +49,7 @@ class AADSSO_AuthorizationHelper
 			array(
 				'grant_type'    => 'authorization_code',
 				'code'          => $code,
-				'redirect_uri'  => $settings->redirect_uri,
+				'redirect_uri'  => $_SERVER['ADD_REDIRECT_URI'] ?: $settings->redirect_uri,
 				'resource'      => $settings->graph_endpoint,
 				'client_id'     => $settings->client_id,
 				'client_secret' => $settings->client_secret

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -535,7 +535,7 @@ class AADSSO {
 	function get_logout_url() {
 
 		// logout_redirect_uri is not a required setting, use default value if none is set
-		$logout_redirect_uri = $this->settings->logout_redirect_uri;
+		$logout_redirect_uri = $_SERVER['LOGOUT_REDIRECT_URI'] ? $this->settings->logout_redirect_uri;
 		if ( empty( $logout_redirect_uri ) ) {
 			$logout_redirect_uri = AADSSO_Settings::get_defaults('logout_redirect_uri');
 		}


### PR DESCRIPTION
Load redirect_uri and logout_redirect_uri from an environment variable if its set, otherwise use the value stored in the database.  
This allows the redirect uris to be set dynamically for review applications without needing to change a value in the database.