### PR TITLE
Add action after_authenticate_success

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ There are several ways Azure AD groups can be created/managed. Some of them requ
  * **Azure AD PowerShell**. The [Azure AD PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/active-directory/install-adv2?view=azureadps-2.0) allows admins and (optionally) users to create and manage groups. (e.g. [New-AzureADGroup](https://docs.microsoft.com/en-us/powershell/module/azuread/new-azureadgroup?view=azureadps-2.0), and [Add-AzureADGroupMember](https://docs.microsoft.com/en-us/powershell/module/azuread/add-azureadgroupmember?view=azureadps-2.0) cmdlets.)
  * **On-premises**. Many large organizations use Azure AD Connect to sync their on-premises AD to Azure AD. This usually includes all on-premises AD groups and memberships. Once these groups are synced to Azrue AD, they can be used with this plugin.
 
+## Action Reference
+
+| Action | Arguments | Description
+| --- | --- | ---
+| aadsso_after_authenticate_success | $jwt, $user | Fires after sucessfull authentication. Usefull for storing aditional data from azure as usermeta
+
 ## Advanced
 
 ### Refreshing the OpenID Connect configuration cache

--- a/aad-sso-wordpress.php
+++ b/aad-sso-wordpress.php
@@ -319,6 +319,8 @@ class AADSSO {
 					if ( true === $this->settings->enable_aad_group_to_wp_role ) {
 						$user = $this->update_wp_user_roles( $user, $group_memberships );
 					}
+
+					do_action('aadsso_after_authenticate_success', $jwt, $user);
 				}
 			} elseif ( isset( $token->error ) ) {
 


### PR DESCRIPTION
The hook fires after successful authentication via Azure.

**Motivation**
It might be useful for various cases, a developer might want to store additional Azure-data in user-meta on login. Or track info like "last login via AD" to be able to identified potentially 'dead' accounts. One might also want to set up more complex group/role-mapping rules then the plugin is capable of today

If we have this in place we could let advanced users put code like this in their application-code:
```
add_action('aadsso_after_authenticate_success', function($jwt, $user){
    update_user_meta($user->ID, 'azure_id', $jwt->aud);
    update_user_meta($user->ID, 'last_login_via_ad', now());
}, 2, 10);
```